### PR TITLE
Add support for older versions and Darwin AArch64

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -12,11 +12,18 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 
 release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.gz"
 
-# Download tar.gz file to the download directory
+# Download tar.gz file to the download directory.
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
-#  Extract contents of tar.gz file into the download directory
-tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+tar_opts=""
+# The release tarballs for Swag v1.7.1 have a top-level directory, unlike those
+# for any other version.
+if [ "$(compare_versions "$ASDF_INSTALL_VERSION" "1.7.1")" -eq 0 ]; then
+  tar_opts="--strip-components=1"
+fi
 
-# Remove the tar.gz file since we don't need to keep it
+# Extract contents of tar.gz file into the download directory.
+tar -xzf "$release_file" -C "$ASDF_DOWNLOAD_PATH" $tar_opts || fail "Could not extract $release_file"
+
+# Remove the tar.gz file since we don't need to keep it.
 rm "$release_file"

--- a/contributing.md
+++ b/contributing.md
@@ -1,12 +1,15 @@
 # Contributing
 
-Testing Locally:
+Testing locally:
 
 ```shell
 asdf plugin test <plugin-name> <plugin-url> [--asdf-tool-version <version>] [--asdf-plugin-gitref <git-ref>] [test-command*]
 
-#
+# E.g., to test the currently-released version:
 asdf plugin test swag https://github.com/behoof4mind/asdf-swag.git "swag --version"
+
+# Or to test against a local commit:
+asdf plugin test swag ./.git --asdf-tool-version 1.8.10 --asdf-plugin-gitref main "swag --version"
 ```
 
 Tests are automatically run in GitHub Actions on push and PR.

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -13,7 +13,6 @@ fail() {
 
 curl_opts=(-fsSL)
 
-# NOTE: You might want to remove this if swag is not hosted on GitHub releases.
 if [ -n "${GITHUB_API_TOKEN:-}" ]; then
   curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
@@ -23,36 +22,158 @@ sort_versions() {
     LC_ALL=C sort -t. -k 1,1 -k 2,2n -k 3,3n -k 4,4n -k 5,5n | awk '{print $2}'
 }
 
+# compare_versions compares two version strings (given as arguments). It prints
+# -1, 0, or 1 if the first version is lower than, equivalent to, or higher than
+# the second version.
+compare_versions() {
+  if [ "$1" = "$2" ]; then
+    echo 0
+    return
+  fi
+
+  lower=$( (
+    echo "$1"
+    echo "$2"
+  ) | sort_versions | head -n 1)
+  [ "$lower" = "$1" ] && echo -1 || echo 1
+}
+
 list_github_tags() {
+  # The sed command strips prefixes “v” and “v.”. Most version tags are
+  # prefixed with “v”, but some (“v.1.2.0”, “v.1.3.0”, “v.1.3.1”, and
+  # “v.1.4.0”) are prefixed with “v.”. We match this with `v\.*` instead of
+  # `v\.\?` for compatibility with FreeBSD sed (macOS).
+
   git ls-remote --tags --refs "$GH_REPO" |
-    grep -o 'refs/tags/.*' | cut -d/ -f3- |
-    sed 's/^v//' # NOTE: You might want to adapt this sed to remove non-version strings from tags
+    grep -o 'refs/tags/.*' |
+    cut -d/ -f3- |
+    grep '^v' |
+    sed 's/^v\.*//'
 }
 
 list_all_versions() {
   list_github_tags
 }
 
+# Through v1.4.0, Swag releases were source-only. After that point, releases
+# have targetted a mixed set of of platforms and architectures:
+#
+# +-------------+-------------------------+-------------------------+
+# |             |          Linux          |         Darwin          |
+# +  Versions   +-------------------------+-------------------------+
+# | (inclusive) | i386 | x86_64 | aarch64 | i386 | x86_64 | aarch64 |
+# +-------------+------+--------+---------+------+--------+---------+
+# |      –1.4.0 |      |        |         |      |        |         |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.4.1–1.6.9 | yes  | yes    |         | yes  | yes    |         |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.7.0       | yes  | yes    | yes     | yes  | yes    |         |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.7.1*      | yes  | yes    | yes     |      | yes    |         |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.7.3–1.8.1 | yes  | yes    | yes     |      | yes    |         |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.8.2**     | yes  | yes    | yes     |      | yes    | yes     |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.8.3–1.8.9 | yes  | yes    | yes     |      | yes    |         |
+# +-------------+------+--------+---------+------+--------+---------+
+# | 1.8.10–     | yes  | yes    | yes     |      | yes    | yes     |
+# +-------------+------+--------+---------+------+--------+---------+
+#
+# - For release versions not denoted by an asterisk,
+#   - the release archive is named swag_${version}_${platform}_${arch}.tar.gz.
+#   - ${platform} is one of “Linux” or “Darwin”, and
+#   - ${arch} is one of “i386”, “x86_64”, or “aarch64”.
+# - For release versions denoted by one asterisk,
+#   - the release archive is named swag_${platform}_${arch}.tar.gz.
+#   - ${platform} is one of “linux” or “darwin”, and
+#   - ${arch} is one of “386”, “amd64”, or “arm64”.
+# - For release versions denoted by two asterisks,
+#   - the release archive is named swag_${version}_${platform}_${arch}.tar.gz.
+#   - ${platform} is one of “linux” or “darwin”, and
+#   - ${arch} is one of “386”, “amd64”, or “arm64”.
+#
+# We expect to be able to use Darwin x86_64 binaries on Darwin aarch64 thanks
+# to Rosetta 2. Otherwise, the host platform and architecture must match the
+# release artifact.
+#
+# We completely ignore Darwin i386. Only a handful of Intel Macs were ever
+# released without 64-bit support – back in 2006. No one is trying to use those
+# machines for development today.
 download_release() {
-  local version filename url
-  version="$1"
-  filename="$2"
+  local version="$1"
+  local filename="$2"
 
-  case $(uname | tr '[:upper:]' '[:lower:]') in
-  linux*)
-    local platform="Linux_x86_64.tar.gz"
+  local version_slug="_$version"
+  local platform="$(uname -s)"
+  local detected_arch="$(uname -m)"
+  local selected_arch=""
+
+  # Broad platform/arch detection. We'll handle version-specific stuff
+  # afterward so we can give more specific error messages.
+  case "$platform" in
+  Linux)
+    case "$detected_arch" in
+    i386 | x86_64 | aarch64) selected_arch="$detected_arch" ;;
+    # Linux i686 should run Linux i386.
+    i686) selected_arch="i386" ;;
+    esac
     ;;
-  darwin*)
-    local platform="Darwin_x86_64.tar.gz"
+  Darwin)
+    case "$detected_arch" in
+    x86_64) selected_arch="$detected_arch" ;;
+    # Darwin aarch64 call itself arm64.
+    arm64) selected_arch="aarch64" ;;
+    esac
     ;;
   *)
-    fail "Platform download not supported. Please, open an issue at $REPORT_URL"
+    echo "Platform $platform not supported!" 2>&1
+    exit 1
     ;;
   esac
 
-  url="$GH_REPO/releases/download/v${version}/${TOOL_NAME}_${version}_${platform}"
+  if [ -z "$selected_arch" ]; then
+    echo "Machine architecture $detected_arch not supported!" 2>&1
+    exit 1
+  fi
 
-  echo "* Downloading $TOOL_NAME release $version from $url"
+  if [ "$(compare_versions "$version" "1.4.1")" -lt 0 ]; then
+    echo "Builds are only available for v1.4.1+!" 2>&1
+    exit 1
+  fi
+
+  if [ "$platform" = "Linux" ] &&
+    [ "$selected_arch" = "aarch64" ] &&
+    [ "$(compare_versions "$version" "1.7.0")" -lt 0 ]; then
+    echo "Linux AArch64 builds are only available for v1.7.0+!" 2>&1
+    exit 1
+  fi
+
+  if [ "$platform" = "Darwin" ] &&
+    [ "$selected_arch" = "aarch64" ] &&
+    [ "$(compare_versions "$version" "1.8.2")" -ne 0 ] &&
+    [ "$(compare_versions "$version" "1.8.10")" -lt 0 ]; then
+    echo "Darwin AArch64 builds are only available for v1.8.2 and v1.8.10+; using x86_64." 2>&1
+    selected_arch="x86_64"
+  fi
+
+  if [ "$(compare_versions "$version" "1.7.1")" -eq 0 ]; then
+    version_slug=""
+  fi
+
+  if [ "$(compare_versions "$version" "1.7.1")" -eq 0 ] ||
+    [ "$(compare_versions "$version" "1.8.2")" -eq 0 ]; then
+    platform="$(echo "$platform" | tr '[:upper:]' '[:lower:]')"
+    case "$selected_arch" in
+    i386) selected_arch="386" ;;
+    x86_64) selected_arch="amd64" ;;
+    aarch64) selected_arch="arm64" ;;
+    esac
+  fi
+
+  local url="$GH_REPO/releases/download/v${version}/swag${version_slug}_${platform}_${selected_arch}.tar.gz"
+
+  echo "* Downloading $TOOL_NAME release $version from $url..."
   curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
 }
 
@@ -77,6 +198,6 @@ install_version() {
     echo "$TOOL_NAME $version installation was successful!"
   ) || (
     rm -rf "$install_path"
-    fail "An error ocurred while installing $TOOL_NAME $version."
+    fail "An error occurred while installing $TOOL_NAME $version."
   )
 }


### PR DESCRIPTION
Hello! I was putting the finishing touches on my own plugin to retrieve Swag when I realized I'd overlooked yours. Your plugin works great for the newest versions of Swag on Linux/Darwin x86_64. However, while trawling through past Swag releases, I noticed that many of them are quite inconsistent: in the architectures they support, in the release archive filenames, and even in the contents of those archives. While I was writing extra code to handle that, I also handled selection of x86_64 and AArch64 builds for Darwin as appropriate and as available. And I thought you might be interested in integrating these features into your plugin.