### PR TITLE
Update Action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v1
+        uses: asdf-vm/actions/plugin-test@v2
         with:
           command: swag --version

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v2
 
       - name: Run ShellCheck
         run: scripts/shellcheck.bash
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install asdf dependencies
-        uses: asdf-vm/actions/install@v1
+        uses: asdf-vm/actions/install@v2
 
       - name: List file to shfmt
         run: shfmt -f .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,10 +5,14 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v2
+      - uses: GoogleCloudPlatform/release-please-action@v3
         with:
           release-type: simple


### PR DESCRIPTION
These newer Action versions are all specified to run on Node 16, [the soon-to-be-default](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/), so that Action runs won't generate warnings about running on Node 12.

The additional write permissions for the “Release” workflow are based on [the Release Please Action documentation][release-please-permissions] and [the equivalent workflow][template] in the newest version of the asdf plugin template.

[release-please-permissions]: https://github.com/google-github-actions/release-please-action#workflow-permissions
[template]: https://github.com/asdf-vm/asdf-plugin-template/blob/a5f24b707c016f0ac3eb03939dde5e8d8ebd746a/template/.github/workflows/release.yml#L8-L10