### PR TITLE
fix: add support for mac m1

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -122,9 +122,7 @@ download_release() {
     ;;
   Darwin)
     case "$detected_arch" in
-    x86_64) selected_arch="$detected_arch" ;;
-    # Darwin aarch64 call itself arm64.
-    arm64) selected_arch="aarch64" ;;
+    arm64 | x86_64) selected_arch="$detected_arch" ;;
     esac
     ;;
   *)


### PR DESCRIPTION
This change allow MacBooks with ARM architecture download the correct version of swag binary.

And resolves the big related on issue: https://github.com/behoof4mind/asdf-swag/issues/5